### PR TITLE
WIP: Viterbi cuda

### DIFF
--- a/deepblast/nw_cuda.py
+++ b/deepblast/nw_cuda.py
@@ -14,17 +14,13 @@ tpb = 32  # threads per block
 @cuda.jit(device=True)
 def _soft_max_device(X, A):
     M = max(X[0], X[1], X[2])
-
     S = 0.0
     for i in range(3):
         A[i] = exp(X[i] - M)
         S += A[i]
-
     for i in range(3):
         A[i] /= S
-
     M += log(S)
-
     return M
 
 

--- a/deepblast/tests/test_viterbi_cuda.py
+++ b/deepblast/tests/test_viterbi_cuda.py
@@ -1,13 +1,23 @@
+from numba import cuda
 import torch
 from torch.autograd import gradcheck
 import torch.testing as tt
 from deepblast.viterbi_cuda import (
-    ViterbiDecoder, ForwardFunction, ForwardDecoder
+    ViterbiDecoder, ForwardFunction, ForwardDecoder,
+    _soft_max_device
 )
+from deepblast.ops import operators
 import deepblast.viterbi_cuda as vc
 import deepblast.viterbi as vb
 from deepblast.constants import x, y, pos_mxys, pos_test, pos_mxy
 import unittest
+
+
+@cuda.jit
+def softmax_kernel(X, S, A, M):
+    # purely for testing purposes
+    i = cuda.grid(1)
+    M[i] = _soft_max_device(X[i], S, A[i])
 
 
 class TestViterbiUtils(unittest.TestCase):
@@ -28,39 +38,68 @@ class TestViterbiUtils(unittest.TestCase):
             self.theta[:, :, :, x] = 0
             self.theta[:, :, :, y] = 0
 
-            self.Ztheta = torch.randn(B, N + 2, M + 2, S, dtype=float_type, device=cuda_device,
-                                      requires_grad=True)
-            self.A = torch.randn(B, N, M, S, S, dtype=float_type, device=cuda_device)
-            self.ZA = torch.randn(B, N, M, S, S, dtype=float_type, device=cuda_device)
+            self.Ztheta = torch.randn(B, N + 2, M + 2, S, dtype=float_type,
+                                      device=cuda_device, requires_grad=True)
+            self.A = torch.randn(B, N, M, S, S, dtype=float_type,
+                                 device=cuda_device)
+            self.ZA = torch.randn(B, N, M, S, S, dtype=float_type,
+                                  device=cuda_device)
             self.B = B
             self.N = N
             self.M = M
             self.S = S
-            self.pos = torch.tensor(pos_mxys, dtype=torch.int8, device=cuda_device).repeat(B, 1, 1)
+            self.pos = torch.tensor(pos_mxys, dtype=torch.int8,
+                                    device=cuda_device).repeat(B, 1, 1)
             self.cuda_device = cuda_device
             self.float_type = float_type
+
+
+    @unittest.skipUnless(torch.cuda.is_available(), 'No GPU was detected')
+    def test_logsumexp(self):
+        with torch.no_grad():
+            A = torch.zeros(1, self.S, dtype=self.float_type,
+                            device=self.cuda_device, requires_grad=False)
+            U = torch.randn(1, self.S, dtype=self.float_type,
+                            device=self.cuda_device, requires_grad=False)
+            A = A.detach()
+            U = U.detach()
+            resM = torch.zeros(1, dtype=self.float_type,
+                               device=self.cuda_device, requires_grad=False)
+            resM = resM.detach()
+            bpg = (1 + (32 - 1)) // 32  # blocks per grid
+            softmax_kernel[32, bpg](U, self.S, A, resM)
+            op = operators['softmax']
+            expM, expA = op.max(U)
+            tt.assert_allclose(resM, expM)
+            tt.assert_allclose(A, expA)
 
     @unittest.skipUnless(torch.cuda.is_available(), 'No GPU was detected')
     def test_forward_pass(self):
         Vt = ForwardFunction.apply(self.theta, self.A, self.pos)
 
-        Vt_ref, _ = vb._forward_pass(self.theta[0], self.A[0], pos_mxys, 'softmax')
+        Vt_ref, _ = vb._forward_pass(self.theta[0], self.A[0],
+                                     pos_mxys, 'softmax')
 
         # Likely huge FP rounding issues between cuda and cpu implementations of log/exp
         assert(abs(Vt[0] - Vt_ref) < 1E-1)
+        self.assertAlmostEqual(Vt.item(), Vt_ref.item())
 
     @unittest.skipUnless(torch.cuda.is_available(), 'No GPU was detected')
     def test_forward_pass_soft(self):
         B, N, M, S = 1, 2, 2, 3
-        theta = torch.ones(B, N, M, S, dtype=self.float_type, device=self.cuda_device)
+        theta = torch.ones(B, N, M, S, dtype=self.float_type,
+                           device=self.cuda_device)
         theta[:, :, :, x] = 0
         theta[:, :, :, y] = 0
-        A = torch.ones(B, N, M, S, S, dtype=self.float_type, device=self.cuda_device)
-        pos = torch.tensor(pos_mxy, dtype=torch.int8, device=self.cuda_device).repeat(B, 1, 1)
+        A = torch.ones(B, N, M, S, S, dtype=self.float_type,
+                       device=self.cuda_device)
+        pos = torch.tensor(pos_mxy, dtype=torch.int8,
+                           device=self.cuda_device).repeat(B, 1, 1)
         res = ForwardFunction.apply(theta, A, pos)
 
         ref = vb.ForwardFunction.apply(theta[0], A[0], pos_mxy, 'softmax')
         print(ref/res[0] - 1.0)
+        self.assertAlmostEqual(res.item(), ref.item())
 
     @unittest.skipUnless(torch.cuda.is_available(), 'No GPU was detected')
     def test_backward_pass_soft(self):
@@ -69,7 +108,7 @@ class TestViterbiUtils(unittest.TestCase):
         A = torch.ones(B, N, M, S, S, device=theta.device, dtype=theta.dtype)
         Q = torch.zeros((B, N + 2, M + 2, S, S), dtype=theta.dtype, device=theta.device)
         resE = torch.zeros((B, N + 2, M + 2, S), dtype=theta.dtype, device=theta.device)
-        pos = torch.tensor(pos_mxys, dtype=torch.int8, device=self.cuda_device).repeat(B, 1, 1)
+        pos = torch.tensor(pos_mxy, dtype=torch.int8, device=self.cuda_device).repeat(B, 1, 1)
         Vt = torch.zeros((B), dtype=theta.dtype, device=theta.device)
         bpg = (B + (vc.tpb - 1)) // vc.tpb
 
@@ -86,61 +125,60 @@ class TestViterbiUtils(unittest.TestCase):
               [0.0000, 0.0000, 0.4683]],
              [[0.0000, 0.4683, 0.0000],
               [0.0634, 0.4683, 0.4683]]])
-
         tt.assert_allclose(resE, expE, atol=1e-3, rtol=1e-3)
 
 
-class TestForwardDecoder(unittest.TestCase):
 
-    def setUp(self):
-        # smoke tests
-        torch.manual_seed(2)
-        # TODO: Compare against hardmax and sparsemax
-        self.operator = 'softmax'
-        self.cuda_device = torch.device('cuda')
-        self.float_type = torch.float32
-
-    def test_grad_needlemanwunsch_function_small(self):
-        B, N, M, S = 1, 2, 5, 5
-        self.theta = torch.rand(B, N, M, S,
-                                requires_grad=True,
-                                device=self.cuda_device, dtype=self.float_type)
-        self.A = torch.rand(B, N, M, S, S,
-                            device=self.cuda_device, dtype=self.float_type)
-        self.Ztheta = torch.rand(B, N, M, S,
-                                 requires_grad=True,
-                                 device=self.cuda_device, dtype=self.float_type)
-        self.Et = torch.Tensor([1.])
-
-        pos = torch.tensor(pos_test, dtype=torch.int8,
-                           device=self.cuda_device).repeat(B, 1, 1)
-        fwd = ForwardDecoder(pos)
-        theta, A = self.theta.double(), self.A.double()
-        theta.requires_grad_()
-        gradcheck(fwd, (theta, A), eps=1e-2)
-
-    def test_grad_needlemanwunsch_function_larger(self):
-        B, N, M, S = 1, 4, 5, 4
-        torch.manual_seed(2)
-        pos = torch.tensor(pos_mxys, dtype=torch.int8,
-                           device=self.cuda_device).repeat(B, 1, 1)
-        self.theta = torch.ones(B, N, M, S,
-                                requires_grad=True,
-                                device=self.cuda_device, dtype=self.float_type)
-
-        self.A = torch.ones(B, N, M, S, S,
-                            device=self.cuda_device, dtype=self.float_type)
-        self.Ztheta = torch.rand(B, N, M, S,
-                                 requires_grad=True,
-                                 device=self.cuda_device,
-                                 dtype=self.float_type)
-        self.Et = torch.Tensor([1.])
-        # TODO: Compare against hardmax and sparsemax
-        self.operator = 'softmax'
-        fwd = ForwardDecoder(pos)
-        theta, A = self.theta.double(), self.A.double()
-        theta.requires_grad_()
-        gradcheck(fwd, (theta, A), eps=1e-2)
+# class TestForwardDecoder(unittest.TestCase):
+#
+#     def setUp(self):
+#         # smoke tests
+#         torch.manual_seed(2)
+#         # TODO: Compare against hardmax and sparsemax
+#         self.operator = 'softmax'
+#         self.cuda_device = torch.device('cuda')
+#         self.float_type = torch.float32
+#
+#     def test_grad_needlemanwunsch_function_small(self):
+#         B, N, M, S = 1, 2, 5, 5
+#         self.theta = torch.rand(B, N, M, S,
+#                                 requires_grad=True,
+#                                 device=self.cuda_device, dtype=self.float_type)
+#         self.A = torch.rand(B, N, M, S, S,
+#                             device=self.cuda_device, dtype=self.float_type)
+#         self.Ztheta = torch.rand(B, N, M, S,
+#                                  requires_grad=True,
+#                                  device=self.cuda_device, dtype=self.float_type)
+#         self.Et = torch.Tensor([1.])
+#         pos = torch.tensor(pos_test, dtype=torch.int8,
+#                            device=self.cuda_device).repeat(B, 1, 1)
+#         fwd = ForwardDecoder(pos)
+#         theta, A = self.theta.double(), self.A.double()
+#         theta.requires_grad_()
+#         gradcheck(fwd, (theta, A), eps=1e-2)
+#
+#     def test_grad_needlemanwunsch_function_larger(self):
+#         B, N, M, S = 1, 4, 5, 4
+#         torch.manual_seed(2)
+#         pos = torch.tensor(pos_mxys, dtype=torch.int8,
+#                            device=self.cuda_device).repeat(B, 1, 1)
+#         self.theta = torch.ones(B, N, M, S,
+#                                 requires_grad=True,
+#                                 device=self.cuda_device, dtype=self.float_type)
+#
+#         self.A = torch.ones(B, N, M, S, S,
+#                             device=self.cuda_device, dtype=self.float_type)
+#         self.Ztheta = torch.rand(B, N, M, S,
+#                                  requires_grad=True,
+#                                  device=self.cuda_device,
+#                                  dtype=self.float_type)
+#         self.Et = torch.Tensor([1.])
+#         # TODO: Compare against hardmax and sparsemax
+#         self.operator = 'softmax'
+#         fwd = ForwardDecoder(pos)
+#         theta, A = self.theta.double(), self.A.double()
+#         theta.requires_grad_()
+#         gradcheck(fwd, (theta, A), eps=1e-2)
 
 
 if __name__ == "__main__":

--- a/deepblast/tests/test_viterbi_cuda.py
+++ b/deepblast/tests/test_viterbi_cuda.py
@@ -102,10 +102,10 @@ class TestForwardDecoder(unittest.TestCase):
 
     def test_grad_needlemanwunsch_function_small(self):
         B, N, M, S = 1, 2, 5, 5
-        self.theta = torch.ones(B, N, M, S,
+        self.theta = torch.rand(B, N, M, S,
                                 requires_grad=True,
                                 device=self.cuda_device, dtype=self.float_type)
-        self.A = torch.ones(B, N, M, S, S,
+        self.A = torch.rand(B, N, M, S, S,
                             device=self.cuda_device, dtype=self.float_type)
         self.Ztheta = torch.rand(B, N, M, S,
                                  requires_grad=True,
@@ -137,7 +137,7 @@ class TestForwardDecoder(unittest.TestCase):
         self.Et = torch.Tensor([1.])
         # TODO: Compare against hardmax and sparsemax
         self.operator = 'softmax'
-        fwd = ForwardDecoder(pos_mxys)
+        fwd = ForwardDecoder(pos)
         theta, A = self.theta.double(), self.A.double()
         theta.requires_grad_()
         gradcheck(fwd, (theta, A), eps=1e-2)

--- a/deepblast/tests/test_viterbi_cuda.py
+++ b/deepblast/tests/test_viterbi_cuda.py
@@ -154,29 +154,6 @@ class TestForwardDecoder(unittest.TestCase):
         theta.requires_grad_()
         gradcheck(fwd, (theta, A), eps=1e-2, atol=1e-2, rtol=1e-2)
 
-#     def test_grad_needlemanwunsch_function_larger(self):
-#         B, N, M, S = 1, 4, 5, 4
-#         torch.manual_seed(2)
-#         pos = torch.tensor(pos_mxys, dtype=torch.int8,
-#                            device=self.cuda_device).repeat(B, 1, 1)
-#         self.theta = torch.ones(B, N, M, S,
-#                                 requires_grad=True,
-#                                 device=self.cuda_device, dtype=self.float_type)
-#
-#         self.A = torch.ones(B, N, M, S, S,
-#                             device=self.cuda_device, dtype=self.float_type)
-#         self.Ztheta = torch.rand(B, N, M, S,
-#                                  requires_grad=True,
-#                                  device=self.cuda_device,
-#                                  dtype=self.float_type)
-#         self.Et = torch.Tensor([1.])
-#         # TODO: Compare against hardmax and sparsemax
-#         self.operator = 'softmax'
-#         fwd = ForwardDecoder(pos)
-#         theta, A = self.theta.double(), self.A.double()
-#         theta.requires_grad_()
-#         gradcheck(fwd, (theta, A), eps=1e-2)
-
 
 if __name__ == "__main__":
 

--- a/deepblast/tests/test_viterbi_cuda.py
+++ b/deepblast/tests/test_viterbi_cuda.py
@@ -57,9 +57,10 @@ class TestViterbiUtils(unittest.TestCase):
     @unittest.skipUnless(torch.cuda.is_available(), 'No GPU was detected')
     def test_logsumexp(self):
         with torch.no_grad():
-            A = torch.zeros(1, self.S, dtype=self.float_type,
+            S = 8
+            A = torch.zeros(1, S, dtype=self.float_type,
                             device=self.cuda_device, requires_grad=False)
-            U = torch.randn(1, self.S, dtype=self.float_type,
+            U = torch.randn(1, S, dtype=self.float_type,
                             device=self.cuda_device, requires_grad=False)
             A = A.detach()
             U = U.detach()
@@ -67,7 +68,7 @@ class TestViterbiUtils(unittest.TestCase):
                                device=self.cuda_device, requires_grad=False)
             resM = resM.detach()
             bpg = (1 + (32 - 1)) // 32  # blocks per grid
-            softmax_kernel[32, bpg](U, self.S, A, resM)
+            softmax_kernel[32, bpg](U, S, A, resM)
             op = operators['softmax']
             expM, expA = op.max(U)
             tt.assert_allclose(resM, expM)

--- a/deepblast/tests/test_viterbi_cuda.py
+++ b/deepblast/tests/test_viterbi_cuda.py
@@ -137,7 +137,7 @@ class TestForwardDecoder(unittest.TestCase):
         self.float_type = torch.float32
 
     def test_grad_needlemanwunsch_function_small(self):
-        B, N, M, S = 1, 2, 5, 5
+        B, N, M, S = 1, 3, 3, 4
         self.theta = torch.rand(B, N, M, S,
                                 requires_grad=True,
                                 device=self.cuda_device, dtype=self.float_type)
@@ -147,13 +147,13 @@ class TestForwardDecoder(unittest.TestCase):
                                  requires_grad=True,
                                  device=self.cuda_device, dtype=self.float_type)
         self.Et = torch.Tensor([1.])
-        pos = torch.tensor(pos_test, dtype=torch.int8,
+        pos = torch.tensor(pos_mxys, dtype=torch.int8,
                            device=self.cuda_device).repeat(B, 1, 1)
         fwd = ForwardDecoder(pos)
         theta, A = self.theta.double(), self.A.double()
         theta.requires_grad_()
-        gradcheck(fwd, (theta, A), eps=1e-2)
-#
+        gradcheck(fwd, (theta, A), eps=1e-2, atol=1e-2, rtol=1e-2)
+
 #     def test_grad_needlemanwunsch_function_larger(self):
 #         B, N, M, S = 1, 4, 5, 4
 #         torch.manual_seed(2)

--- a/deepblast/tests/test_viterbi_cuda.py
+++ b/deepblast/tests/test_viterbi_cuda.py
@@ -122,42 +122,37 @@ class TestViterbiUtils(unittest.TestCase):
 
         expE = vb._backward_pass(Et.cpu(), Q.squeeze().cpu(), pos_mxy)
         expE = expE[1:-1, 1:-1]
-        # expE = torch.Tensor(
-        #     [[[1.0000, 0.0000, 0.0000],
-        #       [0.0000, 0.0000, 0.4683]],
-        #      [[0.0000, 0.4683, 0.0000],
-        #       [0.0634, 0.4683, 0.4683]]])
         tt.assert_allclose(resE, expE, atol=1e-3, rtol=1e-3)
 
 
 
-# class TestForwardDecoder(unittest.TestCase):
-#
-#     def setUp(self):
-#         # smoke tests
-#         torch.manual_seed(2)
-#         # TODO: Compare against hardmax and sparsemax
-#         self.operator = 'softmax'
-#         self.cuda_device = torch.device('cuda')
-#         self.float_type = torch.float32
-#
-#     def test_grad_needlemanwunsch_function_small(self):
-#         B, N, M, S = 1, 2, 5, 5
-#         self.theta = torch.rand(B, N, M, S,
-#                                 requires_grad=True,
-#                                 device=self.cuda_device, dtype=self.float_type)
-#         self.A = torch.rand(B, N, M, S, S,
-#                             device=self.cuda_device, dtype=self.float_type)
-#         self.Ztheta = torch.rand(B, N, M, S,
-#                                  requires_grad=True,
-#                                  device=self.cuda_device, dtype=self.float_type)
-#         self.Et = torch.Tensor([1.])
-#         pos = torch.tensor(pos_test, dtype=torch.int8,
-#                            device=self.cuda_device).repeat(B, 1, 1)
-#         fwd = ForwardDecoder(pos)
-#         theta, A = self.theta.double(), self.A.double()
-#         theta.requires_grad_()
-#         gradcheck(fwd, (theta, A), eps=1e-2)
+class TestForwardDecoder(unittest.TestCase):
+
+    def setUp(self):
+        # smoke tests
+        torch.manual_seed(2)
+        # TODO: Compare against hardmax and sparsemax
+        self.operator = 'softmax'
+        self.cuda_device = torch.device('cuda')
+        self.float_type = torch.float32
+
+    def test_grad_needlemanwunsch_function_small(self):
+        B, N, M, S = 1, 2, 5, 5
+        self.theta = torch.rand(B, N, M, S,
+                                requires_grad=True,
+                                device=self.cuda_device, dtype=self.float_type)
+        self.A = torch.rand(B, N, M, S, S,
+                            device=self.cuda_device, dtype=self.float_type)
+        self.Ztheta = torch.rand(B, N, M, S,
+                                 requires_grad=True,
+                                 device=self.cuda_device, dtype=self.float_type)
+        self.Et = torch.Tensor([1.])
+        pos = torch.tensor(pos_test, dtype=torch.int8,
+                           device=self.cuda_device).repeat(B, 1, 1)
+        fwd = ForwardDecoder(pos)
+        theta, A = self.theta.double(), self.A.double()
+        theta.requires_grad_()
+        gradcheck(fwd, (theta, A), eps=1e-2)
 #
 #     def test_grad_needlemanwunsch_function_larger(self):
 #         B, N, M, S = 1, 4, 5, 4

--- a/deepblast/viterbi_cuda.py
+++ b/deepblast/viterbi_cuda.py
@@ -15,20 +15,14 @@ tpb = 32  # threads per block
 @cuda.jit(device=True)
 def _soft_max_device(X, S, A):
     M = X[0]
-
     for i in range(1, S):
         M = max(M, X[i])
-
-    sumA = 0.0
+    sumA = 0
+    for i in range(S):
+        sumA += exp(X[i] - M)
+    M += log(sumA)
     for i in range(S):
         A[i] = exp(X[i] - M)
-        sumA += A[i]
-
-    for i in range(S):
-        A[i] /= sumA
-
-    M += log(sumA)
-
     return M
 
 


### PR DESCRIPTION
This is a patch to allow for the forward decoder to run.

In the small case, there is something weird going on with the numerical derivative.  All of the finite differences are zero, which is suggestive of a disconnect between backprop steps.  We'll need to figure out the root of this.

```
python test_viterbi_cuda.py TestForwardDecoder.test_grad_needlemanwunsch_function_small
<frozen importlib._bootstrap>:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
E
======================================================================
ERROR: test_grad_needlemanwunsch_function_small (__main__.TestForwardDecoder)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_viterbi_cuda.py", line 120, in test_grad_needlemanwunsch_function_small
    gradcheck(fwd, (theta, A), eps=1e-2)
  File "/home/juermieboop/miniconda3/envs/pytorch/lib/python3.8/site-packages/torch/autograd/gradcheck.py", line 288, in gradcheck
    return fail_test('Jacobian mismatch for output %d with respect to input %d,\n'
  File "/home/juermieboop/miniconda3/envs/pytorch/lib/python3.8/site-packages/torch/autograd/gradcheck.py", line 227, in fail_test
    raise RuntimeError(msg)
RuntimeError: Jacobian mismatch for output 0 with respect to input 0,
numerical:tensor([[0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.],
        [0.]], dtype=torch.float64)
analytical:tensor([[0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.1194],
        [0.1194],
        [0.1194],
        [0.1194],
        [0.1194],
        [0.1194],
        [0.1194],
        [0.1194],
        [0.1194],
        [0.1194],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.0000],
        [0.3456],
        [0.3456],
        [0.3456],
        [0.3456],
        [0.3456]], dtype=torch.float64)


----------------------------------------------------------------------
Ran 1 test in 5.244s

FAILED (errors=1)

```